### PR TITLE
Fix subtitle addition timestamps

### DIFF
--- a/core/subtitleManager.js
+++ b/core/subtitleManager.js
@@ -69,7 +69,7 @@ class SubtitleManager {
       if (isNaN(startTime)) {
         ts = startTime;
       } else {
-        ts = Utils.convertSecondsToStringTimestamp(ts);
+        ts = Utils.convertSecondsToStringTimestamp(startTime);
       }
 
       let end = Utils.convertSecondsToStringTimestamp(Utils.convertStringTimestampToSeconds(ts) + 0.3);
@@ -78,7 +78,7 @@ class SubtitleManager {
         if (isNaN(endTime)) {
           end = endTime;
         } else {
-          end = utils.convertSecondsToStringTimestamp(endTime);
+          end = Utils.convertSecondsToStringTimestamp(endTime);
         }
       }
 


### PR DESCRIPTION
## Summary
- fix wrong variable when converting `startTime`
- use correct `Utils` class for converting `endTime`

## Testing
- `node -e "const fs=require('fs'); const vm=require('vm'); vm.runInThisContext(fs.readFileSync('./core/utils.js')); vm.runInThisContext(fs.readFileSync('./core/eventable.js')); vm.runInThisContext(fs.readFileSync('./core/subtitleManager.js')); console.log('SubtitleManager loaded');"`

------
https://chatgpt.com/codex/tasks/task_e_68453c47ad4c8322b06dadf6c24fa29d