### PR TITLE
Add help drawer UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,11 @@
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K4PQFNT"
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
+    <button id="helpBtn" class="help-btn">?</button>
+    <div id="helpDrawer" class="help-drawer">
+      <button id="closeHelp" class="close-help">X</button>
+      <pre class="help-text"></pre>
+    </div>
     <div class="header">
       <label>
         Video:

--- a/main.js
+++ b/main.js
@@ -19,6 +19,19 @@ window.converters = {
   subrip: new SubRipConverter(),
   localStorage: new LocalStorageConverter()
 };
+const HELP_TEXT = `Ctrl+Z: Undo
+Ctrl+Left Arrow: seeking left
+Ctrl+Right Arrow: seeking right
+Ctrl+Shift+Left Arrow: seeking left fast
+Ctrl+Shift+Right Arrow: seeking right fast
+Alt+D: Set video time to selected subtitle start
+Alt+F: Set video time to selected subtitle end
+Alt+Z: Set start of subtitle to current video time
+Alt+X: Set end of subtitle to current video time
+Alt+C: Create new subtitle
+Alt+N: Set start time of future subtitle
+Alt+M: Create new subtitle with start time from Alt+N and current time.
+Alt+W: Set current time as text.`;
 window.videoPlayer.addListener('timestamp.update', window.subtitleManager.updateUI, window.subtitleManager);
 
 async function initializeSubtitleManagerAutosave() {
@@ -89,6 +102,13 @@ document.getElementById('savejson')
   .addEventListener('click', (e) => {
     window.converters.json.writeData(window.subtitleManager.getData());
   });
+document.getElementById('helpDrawer').querySelector('pre').textContent = HELP_TEXT;
+document.getElementById('helpBtn').addEventListener('click', () => {
+  document.getElementById('helpDrawer').classList.add('open');
+});
+document.getElementById('closeHelp').addEventListener('click', () => {
+  document.getElementById('helpDrawer').classList.remove('open');
+});
 //
 // window.addEventListener('scroll', (e) => {
 //   window.subtitleManager.onScroll();
@@ -126,23 +146,9 @@ window.addEventListener('keydown', (e) => {
 
     let snaps = window.subtitleManager.getSnaps();
 
-    switch (e.code) {
+      switch (e.code) {
         case 'KeyH':
-          alert(`
-Ctrl+Z: Undo
-Ctrl+Left Arrow: seeking left
-Ctrl+Right Arrow: seeking right
-Ctrl+Shift+Left Arrow: seeking left fast
-Ctrl+Shift+Right Arrow: seeking right fast
-Alt+D: Set video time to selected subtitle start
-Alt+F: Set video time to selected subtitle end
-Alt+Z: Set start of subtitle to current video time
-Alt+X: Set end of subtitle to current video time
-Alt+C: Create new subtitle
-Alt+N: Set start time of future subtitle
-Alt+M: Create new subtitle with start time from Alt+N and current time.
-Alt+W: Set current time as text.
-          `)
+          document.getElementById('helpDrawer').classList.add('open');
           break;
         case 'KeyD':
           snaps.map((s) => {

--- a/styles.css
+++ b/styles.css
@@ -152,3 +152,50 @@ input[type="file"] {
 .hint {
   color: #ff9;
 }
+
+.help-btn {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  width: 40px;
+  height: 40px;
+  background: #444;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  z-index: 1000;
+}
+
+.help-drawer {
+  position: fixed;
+  top: 0;
+  right: -300px;
+  width: 300px;
+  height: 100%;
+  background: #222;
+  color: #fff;
+  padding: 10px;
+  box-shadow: 0 0 10px #000;
+  transition: right 0.3s ease;
+  overflow-y: auto;
+  z-index: 999;
+}
+
+.help-drawer.open {
+  right: 0;
+}
+
+.help-drawer .close-help {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  background: #444;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+}
+
+.help-drawer pre {
+  white-space: pre-wrap;
+  margin-top: 40px;
+}


### PR DESCRIPTION
## Summary
- add a fixed help button and slide-out drawer markup
- style new help drawer and button
- implement drawer open/close logic in main.js
- show help drawer on Alt+H

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68453d76d06c8322b9cbe239deaf1a11