### PR TITLE
Add Otter AI transcription API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ OpenAI Whisper. Provide your API key in the input field and click **Transcribe
 5s** to record five seconds from the current position. A new subtitle with the
 transcribed text will be inserted.
 
+Alternatively, you can use the Otter.ai transcription API. Enter your Otter API
+key in the dedicated field and use the **Transcribe 5s (Otter)** button to
+generate subtitles via Otter.ai.
+
 
 #### Why vanila javascript
 

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
     <script src="converters/jsonConverter.js"></script>
     <script src="speech/speechAdapter.js"></script>
     <script src="speech/openaiWhisperAdapter.js"></script>
+    <script src="speech/otterAiAdapter.js"></script>
   </head>
   <body>
   <!-- Google Tag Manager (noscript) -->
@@ -79,6 +80,13 @@
         <input type="password" id="openaiKey" placeholder="sk-...">
       </label>
       <button id="transcribeBtn">Transcribe 5s</button>
+    </div>
+    <div class="header">
+      <label>
+        Otter API Key:
+        <input type="password" id="otterKey" placeholder="token">
+      </label>
+      <button id="transcribeOtterBtn">Transcribe 5s (Otter)</button>
     </div>
     <div class="hscroll">
       <table id="tableHeader">

--- a/speech/otterAiAdapter.js
+++ b/speech/otterAiAdapter.js
@@ -1,0 +1,33 @@
+class OtterAIAdapter extends SpeechAdapter {
+  constructor(config = {}) {
+    super();
+    this.cfg = config;
+  }
+
+  setApiKey(key) {
+    this.cfg.apiKey = key;
+  }
+
+  async transcribe(audioBlob) {
+    if (!this.cfg.apiKey) {
+      throw new Error('API key not set');
+    }
+
+    const formData = new FormData();
+    formData.append('file', audioBlob, 'audio.webm');
+
+    const response = await fetch('https://api.otter.ai/v1/transcriptions', {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Bearer ' + this.cfg.apiKey
+      },
+      body: formData
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to transcribe audio');
+    }
+    const data = await response.json();
+    return data.text;
+  }
+}


### PR DESCRIPTION
## Summary
- integrate new `OtterAIAdapter` for speech transcription
- update UI to allow Otter.ai API key and transcription
- allow choosing adapter in transcription function
- document Otter.ai transcription in README

## Testing
- `npm test` *(fails: could not find package.json)*
- `node --check speech/otterAiAdapter.js`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_6845f7dcb5e48322b61618d9fc240944