### PR TITLE
Enhance API settings panel styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
     </div>
     <div id="configDrawer" class="config-drawer">
       <button id="closeConfig" class="close-config">X</button>
+      <h2 class="drawer-title">API Configuration</h2>
       <label>
         OpenAI API Key:
         <input type="password" id="openaiKey" placeholder="sk-...">

--- a/styles.css
+++ b/styles.css
@@ -243,20 +243,39 @@ input[type="file"] {
 .config-drawer {
   position: fixed;
   top: 0;
-  right: -320px;
-  width: 320px;
+  right: -360px;
+  width: 360px;
   height: 100%;
-  background: #242424;
+  background: linear-gradient(#2a2a2a, #202020);
   color: #eaeaea;
-  padding: 10px 20px;
-  box-shadow: -2px 0 8px rgba(0,0,0,0.5);
+  padding: 20px;
+  box-shadow: -2px 0 8px rgba(0,0,0,0.7);
   transition: right 0.3s ease;
   overflow-y: auto;
   z-index: 998;
+  display: flex;
+  flex-direction: column;
 }
 
 .config-drawer.open {
   right: 0;
+}
+
+.config-drawer .drawer-title {
+  margin: 0 0 20px 0;
+  font-size: 20px;
+  color: #ffcc00;
+}
+
+.config-drawer label {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 15px;
+}
+
+.config-drawer input {
+  margin-top: 5px;
+  width: 100%;
 }
 
 .config-drawer .close-config {


### PR DESCRIPTION
## Summary
- add API panel title
- give config drawer a gradient background, more spacing, and flexible layout
- style drawer labels and inputs for a cleaner look

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845fbdebbe883228434195de69ad05c