### PR TITLE
Add selector for speech service

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,10 @@ You can also add a new subtitle by clicking the **Add Subtitle** button.
 #### Voice to text
 
 You can automatically create subtitles from a short segment of the video using
-OpenAI Whisper. Provide your API key in the input field and click **Transcribe
-5s** to record five seconds from the current position. A new subtitle with the
-transcribed text will be inserted.
-
-Alternatively, you can use the Otter.ai transcription API. Enter your Otter API
-key in the dedicated field and use the **Transcribe 5s (Otter)** button to
-generate subtitles via Otter.ai.
+either the OpenAI Whisper or Otter.ai APIs. Provide your API keys in the
+configuration panel and select which service to use from the dropdown. Then
+click **Transcribe 5s** to record five seconds from the current position and add
+a new subtitle with the transcribed text.
 
 
 #### Why vanila javascript

--- a/index.html
+++ b/index.html
@@ -54,6 +54,13 @@
         Otter API Key:
         <input type="password" id="otterKey" placeholder="token">
       </label>
+      <label>
+        Transcription Service:
+        <select id="transcriptionService">
+          <option value="openai">OpenAI Whisper</option>
+          <option value="otter">Otter.ai</option>
+        </select>
+      </label>
     </div>
     <div class="header">
       <label>
@@ -86,7 +93,6 @@
         <button id="savejson">Save JSON</button>
         <button id="addsubtitle">Add Subtitle</button>
         <button id="transcribeBtn">Transcribe 5s</button>
-        <button id="transcribeOtterBtn">Transcribe 5s (Otter)</button>
       </label>
     </div>
     <div class="hscroll">

--- a/main.js
+++ b/main.js
@@ -23,6 +23,7 @@ window.speechAdapters = {
   openai: new OpenAIWhisperAdapter(),
   otter: new OtterAIAdapter()
 };
+window.currentSpeechService = 'openai';
 const HELP_TEXT = `
   <li><span class="command">Ctrl+Z</span>: Undo</li>
   <li><span class="command">Ctrl+Left Arrow</span>: seeking left</li>
@@ -154,13 +155,13 @@ document.getElementById('openaiKey').addEventListener('change', (e) => {
   window.speechAdapters.openai.setApiKey(e.target.value);
 });
 document.getElementById('transcribeBtn').addEventListener('click', () => {
-  transcribeCurrentSegment();
+  transcribeCurrentSegment(window.currentSpeechService);
 });
 document.getElementById('otterKey').addEventListener('change', (e) => {
   window.speechAdapters.otter.setApiKey(e.target.value);
 });
-document.getElementById('transcribeOtterBtn').addEventListener('click', () => {
-  transcribeCurrentSegment('otter');
+document.getElementById('transcriptionService').addEventListener('change', (e) => {
+  window.currentSpeechService = e.target.value;
 });
 document.getElementById('helpDrawer').querySelector('.help-text').innerHTML = HELP_TEXT;
 document.getElementById('helpBtn').addEventListener('click', () => {

--- a/styles.css
+++ b/styles.css
@@ -22,7 +22,7 @@ body {
   user-select: none;
 }
 
-input, textarea {
+input, textarea, select {
   user-select: auto;
   border-radius: 4px;
   padding: 4px 8px;
@@ -273,7 +273,8 @@ input[type="file"] {
   margin-bottom: 15px;
 }
 
-.config-drawer input {
+.config-drawer input,
+.config-drawer select {
   margin-top: 5px;
   width: 100%;
 }


### PR DESCRIPTION
## Summary
- add dropdown to configuration drawer to choose transcription service
- remove extra transcribe button and use selected service
- wire new selector in JS with a `currentSpeechService` variable
- document new flow in README
- style `<select>` inputs

## Testing
- `node -c main.js && node -c speech/openaiWhisperAdapter.js && node -c speech/otterAiAdapter.js`

------
https://chatgpt.com/codex/tasks/task_e_6845fca41698832289e683908c72e95c