### PR TITLE
Add API key help sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,10 +50,23 @@
         OpenAI API Key:
         <input type="password" id="openaiKey" placeholder="sk-...">
       </label>
+      <details>
+        <summary>Where do I get the OpenAI key?</summary>
+        <p>
+          Create one from
+          <a href="https://platform.openai.com/account/api-keys" target="_blank">the OpenAI API Keys page</a>.
+        </p>
+      </details>
       <label>
         Otter API Key:
         <input type="password" id="otterKey" placeholder="token">
       </label>
+      <details>
+        <summary>Where do I get the Otter key?</summary>
+        <p>
+          Generate an API token in your Otter.ai account settings.
+        </p>
+      </details>
       <label>
         Transcription Service:
         <select id="transcriptionService">

--- a/styles.css
+++ b/styles.css
@@ -273,6 +273,21 @@ input[type="file"] {
   margin-bottom: 15px;
 }
 
+.config-drawer details {
+  margin-bottom: 15px;
+  font-size: 14px;
+}
+
+.config-drawer details summary {
+  cursor: pointer;
+  color: #ffcc00;
+  margin-bottom: 5px;
+}
+
+.config-drawer details p {
+  margin: 0 0 10px 0;
+}
+
 .config-drawer input,
 .config-drawer select {
   margin-top: 5px;


### PR DESCRIPTION
## Summary
- add expandable guides for retrieving API keys in API config drawer
- style `<details>` sections in the panel

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845ff2df24c8322bcb3d5f61f6fe80e