### PR TITLE
Persist API configuration in local storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ either the OpenAI Whisper or Otter.ai APIs. Provide your API keys in the
 configuration panel and select which service to use from the dropdown. Then
 click **Transcribe 5s** to record five seconds from the current position and add
 a new subtitle with the transcribed text.
+Your API keys and selected service are saved in your browser's local storage so
+you don't have to re-enter them every time.
 
 
 #### Why vanila javascript

--- a/main.js
+++ b/main.js
@@ -24,6 +24,35 @@ window.speechAdapters = {
   otter: new OtterAIAdapter()
 };
 window.currentSpeechService = 'openai';
+
+function loadSpeechConfig() {
+  try {
+    const stored = JSON.parse(window.localStorage.getItem('speechConfig') || '{}');
+    if (stored.openaiKey) {
+      window.speechAdapters.openai.setApiKey(stored.openaiKey);
+      document.getElementById('openaiKey').value = stored.openaiKey;
+    }
+    if (stored.otterKey) {
+      window.speechAdapters.otter.setApiKey(stored.otterKey);
+      document.getElementById('otterKey').value = stored.otterKey;
+    }
+    if (stored.service) {
+      window.currentSpeechService = stored.service;
+      document.getElementById('transcriptionService').value = stored.service;
+    }
+  } catch (e) {
+    console.warn('Failed to load speech config', e);
+  }
+}
+
+function saveSpeechConfig() {
+  const cfg = {
+    openaiKey: document.getElementById('openaiKey').value,
+    otterKey: document.getElementById('otterKey').value,
+    service: document.getElementById('transcriptionService').value
+  };
+  window.localStorage.setItem('speechConfig', JSON.stringify(cfg));
+}
 const HELP_TEXT = `
   <li><span class="command">Ctrl+Z</span>: Undo</li>
   <li><span class="command">Ctrl+Left Arrow</span>: seeking left</li>
@@ -165,15 +194,18 @@ document.getElementById('addsubtitle')
   });
 document.getElementById('openaiKey').addEventListener('change', (e) => {
   window.speechAdapters.openai.setApiKey(e.target.value);
+  saveSpeechConfig();
 });
 document.getElementById('transcribeBtn').addEventListener('click', () => {
   transcribeCurrentSegment(window.currentSpeechService);
 });
 document.getElementById('otterKey').addEventListener('change', (e) => {
   window.speechAdapters.otter.setApiKey(e.target.value);
+  saveSpeechConfig();
 });
 document.getElementById('transcriptionService').addEventListener('change', (e) => {
   window.currentSpeechService = e.target.value;
+  saveSpeechConfig();
 });
 document.getElementById('helpDrawer').querySelector('.help-text').innerHTML = HELP_TEXT;
 document.getElementById('helpBtn').addEventListener('click', () => {
@@ -288,4 +320,5 @@ window.addEventListener('keydown', (e) => {
   }
 });
 
+loadSpeechConfig();
 initializeSubtitleManagerAutosave();


### PR DESCRIPTION
## Summary
- save OpenAI/Otter API keys and selected transcription service in local storage
- load saved configuration on start
- document that configuration is stored in the browser

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846001293e4832298e25ddcb67b02c8